### PR TITLE
Show errors for missing or unsupported ROMs

### DIFF
--- a/launcher/recomp-ui/launcher_main.cpp
+++ b/launcher/recomp-ui/launcher_main.cpp
@@ -959,6 +959,21 @@ int check_dump(const std::filesystem::path& dir, const NdsDump& dump) {
     return gba::sha1(data.data(), data.size()).hex() == dump.sha1 ? 1 : 2;
 }
 
+// 0 = rom missing, 1 = verified, 2 = present but wrong hash.
+int check_rom(const std::filesystem::path& path, const char* expected_sha1) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) return 0;
+    const std::streamoff size = file.tellg();
+    if (size <= 0) return 2;
+    std::vector<uint8_t> data(static_cast<std::size_t>(size));
+    file.seekg(0);
+    if (!file.read(reinterpret_cast<char*>(data.data()),
+                   static_cast<std::streamsize>(data.size()))) {
+        return 2;
+    }
+    return gba::sha1(data.data(), data.size()).hex() == expected_sha1 ? 1 : 2;
+}
+
 int nds_bios_verify(const char* bios_path, RecompLauncherCBiosVerify* out) {
     if (!out) return 0;
     std::memset(out, 0, sizeof(*out));
@@ -1059,9 +1074,32 @@ void append_binding_args(std::wstring& command, const ModState& mods) {
 bool launch_runner(const std::filesystem::path& game_dir, const char* rom,
                    int display_layout, bool adaptive,
                    const ModState& mods,
-                   int supersampling, int antialiasing) {
+                   int supersampling, int antialiasing,
+                   const char* expected_sha1) {
     const std::wstring rom_wide = widen(rom);
-    if (rom_wide.empty()) return false;
+    if (rom_wide.empty()) {
+        MessageBoxW(nullptr,
+            L"No ROM was selected. Please provide a legally obtained Metroid "
+            L"Prime Hunters USA revision 0 ROM.",
+            L"Metroid Prime Hunters Recomp", MB_OK | MB_ICONERROR);
+        return false;
+    }
+
+    const int rom_status = check_rom(rom_wide, expected_sha1);
+    if (rom_status == 0) {
+        MessageBoxW(nullptr,
+            L"The selected ROM could not be found or opened.\n\n"
+            L"Please verify that the file exists.",
+            L"Metroid Prime Hunters Recomp", MB_OK | MB_ICONERROR);
+        return false;
+    }
+    if (rom_status == 2) {
+        MessageBoxW(nullptr,
+            L"The selected ROM does not match the supported USA revision 0 dump (AMHE0).\n\n"
+            L"The selected ROM has an unexpected SHA-1.",
+            L"Metroid Prime Hunters Recomp", MB_OK | MB_ICONERROR);
+        return false;
+    }
 
     const std::filesystem::path runner = game_dir / "nds_runner.exe";
     const std::filesystem::path config = game_dir / "game.toml";
@@ -1300,6 +1338,7 @@ int main(int argc, char** argv) {
                          mod_state.adaptive_widescreen,
                          mod_state,
                          settings.supersampling,
-                         settings.antialiasing) ? 0 : 3;
+                         settings.antialiasing,
+                         sha1[0]) ? 0 : 3;
 }
 #endif

--- a/tools/build-linux.sh
+++ b/tools/build-linux.sh
@@ -147,13 +147,28 @@ for f in "$RUNDIR"/*.nds "$RUNDIR"/*.NDS; do
 done
 cd "$RUNDIR" 2>/dev/null || true
 if [ "$#" -eq 0 ]; then
-  if [ -n "$ROM" ]; then
-    exec "$HERE/usr/bin/nds_runner" "$RUNDIR/bios" --interactive --rom "$ROM" --config "$HERE/usr/bin/game.toml" --screen-layout separate --adaptive-widescreen top --startup-mode automatic
+  show_error() {
+    msg="$1"
+    if command -v zenity >/dev/null 2>&1; then zenity --error --text="$msg"
+    elif command -v kdialog >/dev/null 2>&1; then kdialog --error "$msg"
+    elif command -v xmessage >/dev/null 2>&1; then xmessage "$msg"
+    else echo "$msg" >&2; fi
+  }
+  if [ -z "$ROM" ]; then
+    show_error "No Metroid Prime Hunters .nds ROM found. Please place the legally obtained USA revision 0 ROM next to the AppImage."
+    exit 1
   fi
-  exec "$HERE/usr/bin/nds_runner" "$RUNDIR/bios" --interactive --config "$HERE/usr/bin/game.toml" --screen-layout separate --adaptive-widescreen top --startup-mode automatic
+  EXPECTED_SHA1="__INJECT_ROM_SHA1__"
+  ACTUAL_SHA1="$(sha1sum "$ROM" | awk '{print $1}')"
+  if [ "$ACTUAL_SHA1" != "$EXPECTED_SHA1" ]; then
+    show_error "The selected ROM does not match the supported USA revision 0 dump (AMHE0). Expected SHA-1: $EXPECTED_SHA1"
+    exit 1
+  fi
+  exec "$HERE/usr/bin/nds_runner" "$RUNDIR/bios" --interactive --rom "$ROM" --config "$HERE/usr/bin/game.toml" --screen-layout separate --adaptive-widescreen top --startup-mode automatic
 fi
 exec "$HERE/usr/bin/nds_runner" "$@"
 EOF
+sed -i "s/__INJECT_ROM_SHA1__/$ROM_SHA1/" "$APPDIR/AppRun"
 chmod +x "$APPDIR/AppRun" "$APPDIR/usr/bin/$RUNNER_NAME"
 
 echo "[4/4] package AppImage"


### PR DESCRIPTION
Fixes #6.

This adds visible ROM validation errors instead of silently exiting when the expected ROM is missing or unsupported.

Changes:
- Windows launcher now shows an error when no ROM is selected, the ROM cannot be opened, or its SHA-1 does not match the supported USA revision 0 dump.
- Linux AppImage startup now shows a desktop error dialog when no `.nds` file is found or when the detected ROM has the wrong SHA-1.
- Explicit runner arguments on Linux remain unchanged.

Tested on Linux AppImage:
- No ROM: error dialog shown.
- Wrong ROM: unsupported-ROM error dialog shown.
- Correct ROM: game launches normally.

`git diff --check` passes and the change is limited to `launcher/recomp-ui/launcher_main.cpp` and `tools/build-linux.sh`.
