### PR TITLE
Fix Linux FMV bank verification

### DIFF
--- a/tools/build-linux.sh
+++ b/tools/build-linux.sh
@@ -69,7 +69,7 @@ fi
 
 BIN="$RUNNER_BUILD/$RUNNER_NAME"
 test -f "$BIN" || { echo "ERROR: runner not built: $BIN" >&2; exit 1; }
-strings "$BIN" | grep -q mph_arm9_fmv_runtime || {
+grep -a -q mph_arm9_fmv_runtime "$BIN" || {
   echo "ERROR: runner does not contain the MPH FMV runtime bank." >&2
   exit 1
 }


### PR DESCRIPTION
Fixes #8.

`tools/build-linux.sh` enables `pipefail` and previously checked for the FMV runtime bank with:

    strings "$BIN" | grep -q mph_arm9_fmv_runtime

When `grep -q` finds a match, it exits early and `strings` can receive SIGPIPE. With `pipefail` enabled, that makes the pipeline return 141 even though the runtime bank is present.

This replaces the pipeline with a direct binary search:

    grep -a -q mph_arm9_fmv_runtime "$BIN"

Verified locally:

    old check: 141
    new check: 0
    bash -n: 0
    git diff --check: 0

The change is limited to one line in `tools/build-linux.sh`.
