### PR TITLE
Write diagnostics beside the release executable

### DIFF
--- a/launcher/recomp-ui/launcher_main.cpp
+++ b/launcher/recomp-ui/launcher_main.cpp
@@ -362,7 +362,12 @@ std::string read_identity_mac(const std::filesystem::path& bios_dir) {
 std::filesystem::path firmware_state_path(
     const std::filesystem::path& settings_path, bool generated) {
     return settings_path.parent_path() /
-        (generated ? "firmware-generated.bin" : "firmware-retail.bin");
+           (generated ? "firmware-generated.bin" : "firmware-retail.bin");
+}
+
+std::filesystem::path diagnostics_dir_path(
+    const std::filesystem::path& game_dir) {
+    return game_dir / "diagnostics";
 }
 
 std::string read_firmware_state_mac(const std::filesystem::path& path) {
@@ -1549,7 +1554,7 @@ bool launch_runner(const std::filesystem::path& game_dir, const char* rom,
     const std::filesystem::path firmware_state = firmware_state_path(
         mods.settings_path, no_dumps_mode);
     const std::filesystem::path diagnostics_dir =
-        mods.settings_path.parent_path() / "diagnostics";
+        diagnostics_dir_path(game_dir);
 
 #ifdef _WIN32
     const std::wstring rom_wide = widen(rom);

--- a/launcher/recomp-ui/tests/launcher_mod_provider_test.cpp
+++ b/launcher/recomp-ui/tests/launcher_mod_provider_test.cpp
@@ -53,6 +53,9 @@ int main() {
                      "generated firmware state path")) return 85;
         if (!require(retail.filename() == "firmware-retail.bin",
                      "retail firmware state path")) return 86;
+        if (!require(diagnostics_dir_path(root / "release") ==
+                         root / "release" / "diagnostics",
+                     "diagnostics path is release-adjacent")) return 150;
         std::filesystem::create_directories(root);
         std::vector<unsigned char> bytes(128u * 1024u, 0xFFu);
         const unsigned char mac[6] = {0x00, 0x09, 0xBF, 0x12, 0x34, 0x56};


### PR DESCRIPTION
Moves player diagnostics from the hidden per-user settings directory to a visible diagnostics folder next to the extracted release executable. Keeps mods/settings persistence in AppData, but passes --diagnostics-dir as <release>/diagnostics.\n\nValidation:\n- mph-mod-provider-test